### PR TITLE
Fix PPO transformer device handling

### DIFF
--- a/src/tiny_transformer/evaluate.py
+++ b/src/tiny_transformer/evaluate.py
@@ -87,11 +87,10 @@ def evaluate_seal_integrated_transformer(model, dataset, vocab, rev_vocab, max_s
 
 def evaluate_ppo_transformer(model, dataset, vocab, rev_vocab, episodes=100):
     """Evaluate PPO transformer by running episodes in the environment."""
-def evaluate_ppo_transformer(model, dataset, vocab, rev_vocab, episodes=100):
-    """Evaluate PPO transformer by running episodes in the environment."""
     env = MathEnv(vocab, rev_vocab)
     success = 0
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
 
     for _ in range(episodes):
         obs, _ = env.reset()
@@ -99,7 +98,7 @@ def evaluate_ppo_transformer(model, dataset, vocab, rev_vocab, episodes=100):
         final_reward = 0
 
         while not done:
-            obs_tensor = torch.tensor(obs).unsqueeze(0).to(device)
+            obs_tensor = torch.tensor(obs, dtype=torch.long, device=device).unsqueeze(0)
             dist, _ = model(DictList({"text": obs_tensor}))
             action = torch.argmax(dist.probs, dim=-1)
             obs, reward, terminated, truncated, _ = env.step(action.item())

--- a/src/tiny_transformer/ppo_transformer.py
+++ b/src/tiny_transformer/ppo_transformer.py
@@ -7,7 +7,10 @@ class PPOTransformer(ACModel):
     def __init__(self, vocab_size, d_model, nhead, num_layers, dim_feedforward, max_seq_length):
         super(PPOTransformer, self).__init__()
         self.embedding = nn.Embedding(vocab_size, d_model)
-        self.transformer_layer = nn.TransformerEncoderLayer(d_model, nhead, dim_feedforward)
+        # Use batch_first so tensors are (batch, seq, feature)
+        self.transformer_layer = nn.TransformerEncoderLayer(
+            d_model, nhead, dim_feedforward, batch_first=True
+        )
         self.transformer_encoder = nn.TransformerEncoder(self.transformer_layer, num_layers)
         self.actor = nn.Linear(d_model, vocab_size)
         self.critic = nn.Linear(d_model, 1)

--- a/src/tiny_transformer/train.py
+++ b/src/tiny_transformer/train.py
@@ -25,8 +25,6 @@ class MathDataset(Dataset):
                 question = f"{a}/{b}"
                 # Use integer division and return 'inf' for invalid cases
                 answer = str(a // b) if b != 0 and a % b == 0 else "inf"
-                # Use integer division and return 'inf' for invalid cases
-                answer = str(a // b) if b != 0 and a % b == 0 else "inf"
             self.samples.append((question, answer))
 
     def __len__(self):
@@ -118,10 +116,7 @@ def train_seal_integrated_transformer(model, dataset, vocab, rev_vocab, epochs=1
 def train_ppo_transformer(model, dataset, vocab, rev_vocab, epochs=10, gamma=0.99):
     """Train PPO transformer on the MathEnv environment."""
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    optimizer = optim.Adam(model.parameters(), lr=1e-3)
-def train_ppo_transformer(model, dataset, vocab, rev_vocab, epochs=10, gamma=0.99):
-    """Train PPO transformer on the MathEnv environment."""
-    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    model.to(device)
     optimizer = optim.Adam(model.parameters(), lr=1e-3)
     env = MathEnv(vocab, rev_vocab)
 
@@ -134,7 +129,7 @@ def train_ppo_transformer(model, dataset, vocab, rev_vocab, epochs=10, gamma=0.9
         rewards = []
 
         while not done:
-            obs_tensor = torch.tensor(obs).unsqueeze(0).to(device)
+            obs_tensor = torch.tensor(obs, dtype=torch.long, device=device).unsqueeze(0)
             dist, value = model(DictList({"text": obs_tensor}))
             action = dist.sample()
             log_probs.append(dist.log_prob(action))


### PR DESCRIPTION
## Summary
- ensure PPO transformer uses batch-first encoder
- move PPO model and observations to correct device and dtype
- update PPO evaluation for device consistency

## Testing
- `python - <<'PY'
import sys
sys.path.append('src')
from tiny_transformer.train import MathDataset, train_ppo_transformer
from tiny_transformer.evaluate import evaluate_ppo_transformer
from tiny_transformer.ppo_transformer import PPOTransformer
from tiny_transformer.main import VOCAB_SIZE, D_MODEL, NHEAD, NUM_ENCODER_LAYERS, DIM_FEEDFORWARD, MAX_SEQ_LENGTH, vocab, rev_vocab

dataset = MathDataset(num_samples=10)
model = PPOTransformer(VOCAB_SIZE, D_MODEL, NHEAD, NUM_ENCODER_LAYERS, DIM_FEEDFORWARD, MAX_SEQ_LENGTH)
train_ppo_transformer(model, dataset, vocab, rev_vocab, epochs=1)
acc = evaluate_ppo_transformer(model, dataset, vocab, rev_vocab, episodes=5)
print('PPO eval:', acc)
PY`

------
https://chatgpt.com/codex/tasks/task_e_689a6f81d4ac832cb588f6fcfcf0be25